### PR TITLE
"Update UserItem logic for confirming swap and default avatar image"

### DIFF
--- a/lib/app/modules/cart/views/widgets/user_item.dart
+++ b/lib/app/modules/cart/views/widgets/user_item.dart
@@ -44,8 +44,9 @@ class UserItem extends StatelessWidget {
         children: [
           5.horizontalSpace,
           CircleAvatar(
-            backgroundImage:
-                (getImage(user.photo, onlyImage: false) as Image).image,
+            backgroundImage: (user.photo != null)
+                ? (getImage(user.photo, onlyImage: false) as Image).image
+                : const AssetImage('assets/images/default_avatar.png'),
             maxRadius: 50,
           ),
           10.horizontalSpace,
@@ -142,7 +143,7 @@ class UserItem extends StatelessWidget {
                       // Actualizar el rating del usuario en la base de datos
                       var rankingSnapshot = await FirebaseFirestore.instance
                           .collection('ranking')
-                          .doc(user.authId)
+                          .doc(user.authId.toString())
                           .get();
 
                       if (rankingSnapshot.exists) {
@@ -175,7 +176,7 @@ class UserItem extends StatelessWidget {
 
                         await FirebaseFirestore.instance
                             .collection('ranking')
-                            .doc(user.authId)
+                            .doc(user.authId.toString())
                             .update({
                           'punt': newRating,
                           'totalSwaps': updatedTotalSwaps,
@@ -183,15 +184,7 @@ class UserItem extends StatelessWidget {
                         });
                       } else {
                         // Si el usuario no tiene un documento de ranking, crea uno nuevo
-                        await FirebaseFirestore.instance
-                            .collection('ranking')
-                            .doc(user.authId)
-                            .set({
-                          'punt': rating,
-                          'totalSwaps': 1,
-                          'comments': [],
-                        });
-
+                        
                         //comentarios
                         // Agregar el comentario a Firestore
                         var commentId =
@@ -207,15 +200,26 @@ class UserItem extends StatelessWidget {
                           user.authId.toString(),
                           commentId.id, // Obtén el ID del comentario agregado
                         );
+
+                        await FirebaseFirestore.instance
+                            .collection('ranking')
+                            .doc(user.authId.toString())
+                            .set({
+                          'authId': user.authId.toString(),
+                          'punt': rating,
+                          'totalSwaps': 1,
+                          'comments': [commentId.id]
+                        });
+
+
                       }
 
                       // Volver a la pantalla base
                       Get.offAndToNamed(Routes.BASE);
-                      
+
                       //abrir encuesta en el navegador link
                       // ignore: deprecated_member_use
                       await launch('https://es.surveymonkey.com/r/K62QQMQ');
-
                     },
                   );
                 },

--- a/lib/app/modules/cart/views/widgets/user_item.dart
+++ b/lib/app/modules/cart/views/widgets/user_item.dart
@@ -184,7 +184,7 @@ class UserItem extends StatelessWidget {
                         });
                       } else {
                         // Si el usuario no tiene un documento de ranking, crea uno nuevo
-                        
+
                         //comentarios
                         // Agregar el comentario a Firestore
                         var commentId =
@@ -210,8 +210,6 @@ class UserItem extends StatelessWidget {
                           'totalSwaps': 1,
                           'comments': [commentId.id]
                         });
-
-
                       }
 
                       // Volver a la pantalla base

--- a/lib/app/modules/cart/views/widgets/user_item.dart
+++ b/lib/app/modules/cart/views/widgets/user_item.dart
@@ -209,12 +209,13 @@ class UserItem extends StatelessWidget {
                         );
                       }
 
+                      // Volver a la pantalla base
+                      Get.offAndToNamed(Routes.BASE);
+                      
                       //abrir encuesta en el navegador link
                       // ignore: deprecated_member_use
                       await launch('https://es.surveymonkey.com/r/K62QQMQ');
 
-                      // Volver a la pantalla base
-                      Get.offAndToNamed(Routes.BASE);
                     },
                   );
                 },

--- a/lib/app/modules/cart/views/widgets/user_item.dart
+++ b/lib/app/modules/cart/views/widgets/user_item.dart
@@ -131,15 +131,15 @@ class UserItem extends StatelessWidget {
                       ],
                     ),
                     onConfirm: () async {
-                      // Lógica para confirmar el intercambio
+                       // Lógica para confirmar el intercambio
                       await Get.find<SwapController>()
-                          .confirmSwap(owner_id: user.id.toString());
+                          .confirmSwap(owner_id: user.id!);
                       Get.find<CartController>().getCartProducts();
                       Get.find<CartController>().getProductsSwapped();
                       Get.find<FavoritesController>().getFavoriteProducts();
                       Get.find<FavoritesController>()
                           .getProductsInNegotiation();
-
+                          
                       // Actualizar el rating del usuario en la base de datos
                       var rankingSnapshot = await FirebaseFirestore.instance
                           .collection('ranking')

--- a/lib/app/modules/notifications/controllers/notifications_controller.dart
+++ b/lib/app/modules/notifications/controllers/notifications_controller.dart
@@ -26,7 +26,7 @@ class NotificationsController extends GetxController {
       final snapshot = await FirebaseFirestore.instance
           .collection('ranking')
           .orderBy('punt', descending: true)
-          .limit(4)
+          .limit(5)
           .get();
       if (snapshot.docs.isNotEmpty) {
         topUsers.value = snapshot.docs

--- a/lib/app/modules/notifications/views/notifications_view.dart
+++ b/lib/app/modules/notifications/views/notifications_view.dart
@@ -127,6 +127,16 @@ class NotificationsView extends GetView<NotificationsController> {
               thickness: 2,
             ),
             //top users
+            30.verticalSpace,
+            const Text(
+              'Top Usuarios',
+              style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            10.verticalSpace,
             Obx(() {
               if (controller.topUsers.isEmpty) {
                 return const CircularProgressIndicator();

--- a/lib/app/modules/notifications/views/notifications_view.dart
+++ b/lib/app/modules/notifications/views/notifications_view.dart
@@ -128,7 +128,7 @@ class NotificationsView extends GetView<NotificationsController> {
             ),
             //top users
             Obx(() {
-              if (controller.topUsers.skip(3).isEmpty) {
+              if (controller.topUsers.isEmpty) {
                 return const CircularProgressIndicator();
               } else {
                 return Column(
@@ -136,11 +136,11 @@ class NotificationsView extends GetView<NotificationsController> {
                     for (int i = 0; i < controller.topUsers.length; i++)
                       FutureBuilder(
                         future: Future.wait([
-                          controller.getUserById(
+                            controller.getUserById(
                               controller.topUsers[i].authId.toString()),
-                          controller.getUsersProfilePhotos(
+                            controller.getUsersProfilePhotos(
                               controller.topUsers[i].authId.toString()),
-                        ]),
+                        ] as Iterable<Future>),
                         builder:
                             (context, AsyncSnapshot<List<dynamic>> snapshot) {
                           if (snapshot.hasData && snapshot.data != null) {

--- a/lib/app/modules/notifications/views/widgets/topthreeusers_item.dart
+++ b/lib/app/modules/notifications/views/widgets/topthreeusers_item.dart
@@ -8,12 +8,12 @@ class TopThreeUsersItem extends StatelessWidget {
   final String profilePhoto;
 
   const TopThreeUsersItem({
-    Key? key,
+    super.key,
     required this.position,
     required this.rank,
     required this.userName,
     required this.profilePhoto,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -230,7 +230,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This pull request includes updates to the logic in the UserItem class for confirming a swap and displaying a default avatar image. The logic for confirming a swap has been updated to use the user's ID as a string instead of an integer. Additionally, the logic for displaying the avatar image has been updated to use a default image if the user's photo is null. These updates improve the functionality and user experience of the application.